### PR TITLE
 Complement the ingest change that qualifies the account with its type

### DIFF
--- a/src/main/java/com/rackspace/salus/event/manage/config/TenantMappingProperties.java
+++ b/src/main/java/com/rackspace/salus/event/manage/config/TenantMappingProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.config;
+
+import java.util.Map;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties("tenant-mapping")
+@Component
+@Data
+public class TenantMappingProperties {
+
+  /**
+   * When configured, tenants will be processed into qualified accounts during Kapacitor setup
+   * by mapping a tenant type prefix given as a key here into a qualified account with the mapped
+   * account type value.
+   */
+  Map<String,String> tenantToAccountTypes;
+
+  /**
+   * When no prefix is found on a given tenant, this is the account type prefix that will be
+   * pre-pended to the tenant value separated by the
+   */
+  String defaultAccountType;
+
+  /**
+   * The delimiter to expect when processing tenant values.
+   */
+  String tenantDelimiter = ":";
+
+  /**
+   * The delimiter to use when constructing a qualified account value.
+   */
+  String qualifiedAccountDelimiter = ":";
+}

--- a/src/main/java/com/rackspace/salus/event/manage/services/AccountQualifierService.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/AccountQualifierService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.services;
+
+import com.rackspace.salus.event.manage.config.TenantMappingProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Service
+@Slf4j
+public class AccountQualifierService {
+
+  private final TenantMappingProperties properties;
+
+  @Autowired
+  public AccountQualifierService(TenantMappingProperties properties) {
+    this.properties = properties;
+  }
+
+  public String convertFromTenant(String tenantId) {
+
+    if (properties.getTenantToAccountTypes() == null) {
+      log.debug("Skipping tenant type mapping since configuration is absent");
+      return tenantId;
+    }
+
+    final String[] tenantParts = tenantId.split(properties.getTenantDelimiter(), 2);
+
+    if (tenantParts.length == 1) {
+      Assert.state(
+          properties.getDefaultAccountType() != null,
+          "defaultAccountType needs to be configured in TenantMappingProperties"
+      );
+
+      log.debug("No prefix on tenant, mapping qualified account with default type");
+      return properties.getDefaultAccountType() +
+          properties.getQualifiedAccountDelimiter() +
+          tenantId;
+    }
+
+    final String tenantPrefix = tenantParts[0];
+
+    final String accountType = properties.getTenantToAccountTypes().get(tenantPrefix);
+    if (StringUtils.hasText(accountType)) {
+      log.debug("Found accountType={} for tenant prefix={}", accountType, tenantPrefix);
+      return accountType +
+          properties.getQualifiedAccountDelimiter() +
+          tenantParts[1];
+    } else {
+      log.warn("No account type mapping found for tenant prefix={}", tenantPrefix);
+      return properties.getDefaultAccountType() +
+          properties.getQualifiedAccountDelimiter() +
+          tenantParts[1];
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/manage/services/TasksService.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TasksService.java
@@ -46,17 +46,19 @@ public class TasksService {
   private final EventEngineTaskRepository eventEngineTaskRepository;
   private final TaskIdGenerator taskIdGenerator;
   private final TickScriptBuilder tickScriptBuilder;
+  private final AccountQualifierService accountQualifierService;
 
   @Autowired
   public TasksService(EventEnginePicker eventEnginePicker, RestTemplateBuilder restTemplateBuilder,
                       EventEngineTaskRepository eventEngineTaskRepository,
-                      TaskIdGenerator taskIdGenerator, TickScriptBuilder tickScriptBuilder) {
+                      TaskIdGenerator taskIdGenerator, TickScriptBuilder tickScriptBuilder,
+                      AccountQualifierService accountQualifierService) {
     this.eventEnginePicker = eventEnginePicker;
     this.restTemplate = restTemplateBuilder.build();
     this.eventEngineTaskRepository = eventEngineTaskRepository;
     this.taskIdGenerator = taskIdGenerator;
     this.tickScriptBuilder = tickScriptBuilder;
-
+    this.accountQualifierService = accountQualifierService;
   }
 
   public EventEngineTask createTask(String tenantId, CreateTask in) {
@@ -65,7 +67,7 @@ public class TasksService {
     final Task task = Task.builder()
         .id(taskId.getKapacitorTaskId())
         .dbrps(Collections.singletonList(DbRp.builder()
-            .db(tenantId)
+            .db(accountQualifierService.convertFromTenant(tenantId))
             .rp(InfluxScope.INGEST_RETENTION_POLICY)
             .build()))
         .script(tickScriptBuilder.build(tenantId, in.getMeasurement(), in.getScenario()))

--- a/src/test/java/com/rackspace/salus/event/manage/services/AccountQualifierServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/AccountQualifierServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.services;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.event.manage.config.TenantMappingProperties;
+import java.util.Collections;
+import org.junit.Test;
+
+public class AccountQualifierServiceTest {
+
+  @Test
+  public void convertFromTenant_defaultNoMapping() {
+    final TenantMappingProperties properties = new TenantMappingProperties();
+
+    final AccountQualifierService service = new AccountQualifierService(properties);
+
+    assertThat(
+        service.convertFromTenant("123456"),
+        equalTo("123456")
+    );
+    assertThat(
+        service.convertFromTenant("any:123456"),
+        equalTo("any:123456")
+    );
+
+  }
+
+  @Test
+  public void convertFromTenant_noTenantPrefix() {
+    final TenantMappingProperties properties = new TenantMappingProperties()
+        .setTenantToAccountTypes(Collections.singletonMap("hybrid", "CORE"))
+        .setDefaultAccountType("UNKNOWN");
+
+    final AccountQualifierService service = new AccountQualifierService(properties);
+
+    assertThat(
+        service.convertFromTenant("123456"),
+        equalTo("UNKNOWN:123456")
+    );
+
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void convertFromTenant_noTenantPrefix_noDefaultConfig() {
+    final TenantMappingProperties properties = new TenantMappingProperties()
+        .setTenantToAccountTypes(Collections.singletonMap("hybrid", "CORE"));
+
+    final AccountQualifierService service = new AccountQualifierService(properties);
+
+    service.convertFromTenant("123456"); // should fail
+
+  }
+
+  @Test
+  public void convertFromTenant_tenantPrefixKnown() {
+    final TenantMappingProperties properties = new TenantMappingProperties()
+        .setTenantToAccountTypes(Collections.singletonMap("hybrid", "CORE"))
+        .setDefaultAccountType("UNKNOWN");
+
+    final AccountQualifierService service = new AccountQualifierService(properties);
+
+    assertThat(
+        service.convertFromTenant("hybrid:123456"),
+        equalTo("CORE:123456")
+    );
+
+  }
+
+  @Test
+  public void convertFromTenant_tenantPrefixUnknown() {
+    final TenantMappingProperties properties = new TenantMappingProperties()
+        .setTenantToAccountTypes(Collections.singletonMap("hybrid", "CORE"))
+        .setDefaultAccountType("UNKNOWN");
+
+    final AccountQualifierService service = new AccountQualifierService(properties);
+
+    assertThat(
+        service.convertFromTenant("other:123456"),
+        equalTo("UNKNOWN:123456")
+    );
+
+  }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    platform: h2
+  jpa:
+    hibernate:
+      # We need to customize the json column type for h2 via schema sql, but we can't do that and
+      # use Hibernate auto DDL:
+      # https://docs.spring.io/spring-boot/docs/current/reference/html/howto-database-initialization.html#howto-initialize-a-database-using-spring-jdbc
+      ddl-auto: none

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -1,0 +1,13 @@
+-- h2 doesn't have a JSON type, but for integration/unit tests we can simulate one as a TEXT type
+CREATE DOMAIN IF NOT EXISTS json AS TEXT;
+
+-- and we have to go all in and take over schema creation from Hibernate
+CREATE TABLE event_engine_task
+(
+  id          varchar(255) not null,
+  measurement varchar(255) not null,
+  scenario    json         not null,
+  task_id     varchar(255) not null,
+  tenant_id   varchar(255) not null,
+  primary key (id)
+);


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-262

# What

This PR complements https://github.com/racker/salus-event-engine-ingest/pull/2 by resolving the Kapacitor database name with the same qualified account convention.

I also noticed the app context loading unit test was succeeding, but throwing errors about H2 not supporting the JSON column type used in the scenario entity. 

# How

Use a configuration driven approach that in production will include mappings like "hybrid -> CORE" and default to "ENCORE".

## How to test

Added a unit test for the tenant to qualified account mapping logic.