### PR TITLE
Allow different expressions for different levels for consecutiveCount

### DIFF
--- a/src/main/java/com/rackspace/salus/event/manage/model/Expression.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/Expression.java
@@ -1,10 +1,13 @@
 package com.rackspace.salus.event.manage.model;
 
+import com.rackspace.salus.event.manage.model.validator.ExpressionValidator;
+import com.rackspace.salus.event.manage.model.validator.ExpressionValidator.ComparatorValidation;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
+@ExpressionValidator.ComparatorValidation()
 public class Expression {
   @NotEmpty
   String field;

--- a/src/main/java/com/rackspace/salus/event/manage/model/Expression.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/Expression.java
@@ -7,13 +7,14 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-@ExpressionValidator.ComparatorValidation()
+
 public class Expression {
   @NotEmpty
   String field;
   @NotNull
   Number threshold;
   @NotEmpty
+  @ExpressionValidator.ComparatorValidation()
   String comparator;
 
 }

--- a/src/main/java/com/rackspace/salus/event/manage/model/Expression.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/Expression.java
@@ -1,0 +1,16 @@
+package com.rackspace.salus.event.manage.model;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class Expression {
+  @NotEmpty
+  String field;
+  @NotNull
+  Number threshold;
+  @NotEmpty
+  String comparator;
+
+}

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
@@ -32,7 +32,8 @@ public class TaskParameters {
   @ValidLabelKeys
   Map<String, String> labelSelector;
 
-  private class LevelExpression {
+  @Data
+  public class LevelExpression {
     Expression expression;
     Integer consecutiveCount;
   }

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
@@ -25,15 +25,15 @@ import java.util.Map;
 
 @Data
 public class TaskParameters {
-  levelExpression consecutiveInfo;
-  levelExpression consecutiveWarning;
-  levelExpression consecutiveCritical;
+  LevelExpression info;
+  LevelExpression warning;
+  LevelExpression critical;
 
   @ValidLabelKeys
   Map<String, String> labelSelector;
 
-  private class levelExpression {
-    Expression baseExpression;
+  private class LevelExpression {
+    Expression expression;
     Integer consecutiveCount;
   }
 }

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
@@ -25,17 +25,15 @@ import java.util.Map;
 
 @Data
 public class TaskParameters {
-  @NotEmpty
-  String field;
-  @NotNull
-  Number threshold;
-  @NotEmpty
-  String comparator;
-
-  Integer consecutiveInfo;
-  Integer consecutiveWarning;
-  Integer consecutiveCritical;
+  levelExpression consecutiveInfo;
+  levelExpression consecutiveWarning;
+  levelExpression consecutiveCritical;
 
   @ValidLabelKeys
   Map<String, String> labelSelector;
+
+  private class levelExpression {
+    Expression baseExpression;
+    Integer consecutiveCount;
+  }
 }

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskParameters.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.event.manage.model;
 
+import com.rackspace.salus.event.manage.model.validator.TaskParametersValidator;
 import com.rackspace.salus.telemetry.model.ValidLabelKeys;
 import lombok.Data;
 
@@ -24,6 +25,7 @@ import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 @Data
+@TaskParametersValidator.AtLeastOneOf()
 public class TaskParameters {
   LevelExpression info;
   LevelExpression warning;

--- a/src/main/java/com/rackspace/salus/event/manage/model/validator/ExpressionValidator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/validator/ExpressionValidator.java
@@ -1,0 +1,39 @@
+package com.rackspace.salus.event.manage.model.validator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.rackspace.salus.event.manage.model.Expression;
+import com.rackspace.salus.event.manage.model.validator.TaskParametersValidator.AtLeastOneOf;
+import com.rackspace.salus.event.manage.types.Comparator;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+/**
+ * Validates on object creation whether the validator is one of the four acceptable options that we allow
+ */
+public class ExpressionValidator implements ConstraintValidator<AtLeastOneOf, Expression> {
+
+  @Override
+  public boolean isValid(Expression expression, ConstraintValidatorContext context) {
+    return Comparator.valid(expression.getComparator());
+  }
+
+  @Target({TYPE, ANNOTATION_TYPE}) // class level constraint
+  @Retention(RUNTIME)
+  @Constraint(validatedBy = ExpressionValidator.class) // validator
+  @Documented
+  public @interface ComparatorValidation {
+    String message() default "Valid comparators are: >, >=, <, <="; // default error message
+
+    Class<?>[] groups() default {}; // required
+
+    Class<? extends Payload>[] payload() default {}; // required
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/manage/model/validator/ExpressionValidator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/validator/ExpressionValidator.java
@@ -1,6 +1,7 @@
 package com.rackspace.salus.event.manage.model.validator;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -25,7 +26,7 @@ public class ExpressionValidator implements ConstraintValidator<AtLeastOneOf, Ex
     return Comparator.valid(expression.getComparator());
   }
 
-  @Target({TYPE, ANNOTATION_TYPE}) // class level constraint
+  @Target({FIELD, ANNOTATION_TYPE}) // class level constraint
   @Retention(RUNTIME)
   @Constraint(validatedBy = ExpressionValidator.class) // validator
   @Documented

--- a/src/main/java/com/rackspace/salus/event/manage/model/validator/ExpressionValidator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/validator/ExpressionValidator.java
@@ -2,11 +2,9 @@ package com.rackspace.salus.event.manage.model.validator;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import com.rackspace.salus.event.manage.model.Expression;
-import com.rackspace.salus.event.manage.model.validator.TaskParametersValidator.AtLeastOneOf;
+import com.rackspace.salus.event.manage.model.validator.ExpressionValidator.ComparatorValidation;
 import com.rackspace.salus.event.manage.types.Comparator;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -19,11 +17,11 @@ import javax.validation.Payload;
 /**
  * Validates on object creation whether the validator is one of the four acceptable options that we allow
  */
-public class ExpressionValidator implements ConstraintValidator<AtLeastOneOf, Expression> {
+public class ExpressionValidator implements ConstraintValidator<ComparatorValidation, String> {
 
   @Override
-  public boolean isValid(Expression expression, ConstraintValidatorContext context) {
-    return Comparator.valid(expression.getComparator());
+  public boolean isValid(String comparator, ConstraintValidatorContext context) {
+    return Comparator.valid(comparator);
   }
 
   @Target({FIELD, ANNOTATION_TYPE}) // class level constraint

--- a/src/main/java/com/rackspace/salus/event/manage/model/validator/TaskParametersValidator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/validator/TaskParametersValidator.java
@@ -13,6 +13,11 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
 
+/**
+ * This validator makes sure that at least one parameter level is defined.
+ * Tasks can't accomplish anything without any parameters defined because they
+ * will have nothing to alert on.
+ */
 public class TaskParametersValidator implements ConstraintValidator<TaskParametersValidator.AtLeastOneOf, TaskParameters> {
 
   @Override

--- a/src/main/java/com/rackspace/salus/event/manage/model/validator/TaskParametersValidator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/validator/TaskParametersValidator.java
@@ -41,7 +41,7 @@ public class TaskParametersValidator implements ConstraintValidator<TaskParamete
   @Constraint(validatedBy = TaskParametersValidator.class) // validator
   @Documented
   public @interface AtLeastOneOf {
-    String message() default "At least one of the Expressions must be set"; // default error message
+    String message() default "At least one of the level expressions must be set"; // default error message
 
     Class<?>[] groups() default {}; // required
 

--- a/src/main/java/com/rackspace/salus/event/manage/model/validator/TaskParametersValidator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/validator/TaskParametersValidator.java
@@ -1,0 +1,50 @@
+package com.rackspace.salus.event.manage.model.validator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.rackspace.salus.event.manage.model.TaskParameters;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+public class TaskParametersValidator implements ConstraintValidator<TaskParametersValidator.AtLeastOneOf, TaskParameters> {
+
+  @Override
+  public boolean isValid(TaskParameters parameters, ConstraintValidatorContext context) {
+    int count = 0;
+
+    if(parameters.getCritical() == null) {
+      count++;
+    }
+    if(parameters.getInfo() == null) {
+      count++;
+    }
+    if(parameters.getWarning() == null) {
+      count++;
+    }
+    //nothing is set
+    if(count == 3) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  @Target({TYPE, ANNOTATION_TYPE}) // class level constraint
+  @Retention(RUNTIME)
+  @Constraint(validatedBy = TaskParametersValidator.class) // validator
+  @Documented
+  public @interface AtLeastOneOf {
+    String message() default "At least one of the Expressions must be set"; // default error message
+
+    Class<?>[] groups() default {}; // required
+
+    Class<? extends Payload>[] payload() default {}; // required
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/manage/services/TaskIdGenerator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TaskIdGenerator.java
@@ -44,12 +44,5 @@ public class TaskIdGenerator {
     return String.format("%s-*", tenantId);
   }
 
-  public String generateAlertId(String tenantId, String measurement, String field) {
-    return String.join(":",
-        tenantId,
-        String.format("{{index .Tags \"%s\"}}", Tags.RESOURCE_ID),
-        measurement,
-        field
-    );
-  }
+
 }

--- a/src/main/java/com/rackspace/salus/event/manage/services/TasksService.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TasksService.java
@@ -66,9 +66,9 @@ public class TasksService {
 
   public EventEngineTask createTask(String tenantId, CreateTask in) {
 
-    if (!Comparator.valid(in.getTaskParameters().getComparator())) {
+    if (!Comparator.valid(in.getTaskParameters().getCritical().getExpression().getComparator())) {
         throw new BackendException(new ResponseEntity<>(HttpStatus.BAD_REQUEST),
-                "Invalid comparator " + in.getTaskParameters().getComparator());
+                "Invalid comparator " + in.getTaskParameters().getCritical().getExpression().getComparator());
     }
 
     final TaskId taskId = taskIdGenerator.generateTaskId(tenantId, in.getMeasurement());

--- a/src/main/java/com/rackspace/salus/event/manage/services/TasksService.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TasksService.java
@@ -66,11 +66,6 @@ public class TasksService {
 
   public EventEngineTask createTask(String tenantId, CreateTask in) {
 
-    if (!Comparator.valid(in.getTaskParameters().getCritical().getExpression().getComparator())) {
-        throw new BackendException(new ResponseEntity<>(HttpStatus.BAD_REQUEST),
-                "Invalid comparator " + in.getTaskParameters().getCritical().getExpression().getComparator());
-    }
-
     final TaskId taskId = taskIdGenerator.generateTaskId(tenantId, in.getMeasurement());
     final Task task = Task.builder()
         .id(taskId.getKapacitorTaskId())

--- a/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.event.manage.services;
 
+import com.rackspace.salus.event.manage.model.Expression;
 import com.rackspace.salus.event.manage.model.TaskParameters;
 import com.rackspace.salus.event.manage.model.TaskParameters.LevelExpression;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
@@ -70,21 +71,14 @@ public class TickScriptBuilder {
         .labelsAvailable(labelsAvailable)
         .measurement(measurement)
         .details("task={{.TaskName}}")
-        .critExpression(String.format("\"%s\" %s %s",
-            taskParameters.getCritical().getExpression().getField(),
-            taskParameters.getCritical().getExpression().getComparator(),
-            taskParameters.getCritical().getExpression().getThreshold()))
+        .critExpression(taskParameters.getCritical() != null ?
+            buildTICKExpression(taskParameters.getCritical().getExpression()) :
+            null)
         .infoExpression(taskParameters.getInfo() != null ?
-            String.format("\"%s\" %s %s",
-            taskParameters.getInfo().getExpression().getField(),
-            taskParameters.getInfo().getExpression().getComparator(),
-            taskParameters.getInfo().getExpression().getThreshold()) :
+            buildTICKExpression(taskParameters.getInfo().getExpression()) :
             null)
         .warnExpression(taskParameters.getWarning() != null ?
-            String.format("\"%s\" %s %s",
-                taskParameters.getWarning().getExpression().getField(),
-                taskParameters.getWarning().getExpression().getComparator(),
-                taskParameters.getWarning().getExpression().getThreshold()) :
+            buildTICKExpression(taskParameters.getWarning().getExpression()) :
             null)
         .infoCount(
             taskParameters.getInfo() != null ?
@@ -96,6 +90,10 @@ public class TickScriptBuilder {
             : null)
         .critCount(String.format("\"state_count\" >= %d", taskParameters.getCritical().getConsecutiveCount()))
         .build());
+  }
+
+  public String buildTICKExpression(Expression expression) {
+    return String.format("\"%s\" %s %s", expression.getField(),  expression.getComparator(), expression.getThreshold());
   }
 
   @Data @Builder

--- a/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
@@ -71,15 +71,9 @@ public class TickScriptBuilder {
         .labelsAvailable(labelsAvailable)
         .measurement(measurement)
         .details("task={{.TaskName}}")
-        .critExpression(taskParameters.getCritical() != null ?
-            buildTICKExpression(taskParameters.getCritical().getExpression()) :
-            null)
-        .infoExpression(taskParameters.getInfo() != null ?
-            buildTICKExpression(taskParameters.getInfo().getExpression()) :
-            null)
-        .warnExpression(taskParameters.getWarning() != null ?
-            buildTICKExpression(taskParameters.getWarning().getExpression()) :
-            null)
+        .critExpression(buildTICKExpression(taskParameters.getCritical()))
+        .infoExpression(buildTICKExpression(taskParameters.getInfo()))
+        .warnExpression(buildTICKExpression(taskParameters.getWarning()))
         .infoCount(
             taskParameters.getInfo() != null ?
                 String.format("\"info_count\" >= %d", taskParameters.getInfo().getConsecutiveCount())
@@ -88,12 +82,15 @@ public class TickScriptBuilder {
           taskParameters.getWarning() != null ?
             String.format("\"warn_count\" >= %d",taskParameters.getWarning().getConsecutiveCount())
             : null)
-        .critCount(String.format("\"state_count\" >= %d", taskParameters.getCritical().getConsecutiveCount()))
+        .critCount(String.format("\"crit_count\" >= %d", taskParameters.getCritical().getConsecutiveCount()))
         .build());
   }
 
-  public String buildTICKExpression(Expression expression) {
-    return String.format("\"%s\" %s %s", expression.getField(),  expression.getComparator(), expression.getThreshold());
+  public String buildTICKExpression(LevelExpression expression) {
+    return expression != null ? String.format("\"%s\" %s %s", expression.getExpression().getField(),
+        expression.getExpression().getComparator(),
+        expression.getExpression().getThreshold()) :
+        null;
   }
 
   @Data @Builder

--- a/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
@@ -84,7 +84,10 @@ public class TickScriptBuilder {
           taskParameters.getWarning() != null ?
             String.format("\"warn_count\" >= %d",taskParameters.getWarning().getConsecutiveCount())
             : null)
-        .critCount(String.format("\"crit_count\" >= %d", taskParameters.getCritical().getConsecutiveCount()))
+        .critCount(
+            taskParameters.getCritical() != null ?
+                String.format("\"crit_count\" >= %d", taskParameters.getCritical().getConsecutiveCount())
+                :null)
         .build());
   }
 

--- a/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
@@ -60,14 +60,16 @@ public class TickScriptBuilder {
     this.taskIdGenerator = taskIdGenerator;
   }
 
-  public String build(String tenantId, String measurement,  TaskParameters taskParameters) {
+  public String build(String tenantId, String measurement, TaskParameters taskParameters) {
     boolean labelsAvailable = false;
     if(taskParameters.getLabelSelector() != null)
       labelsAvailable = true;
-    levelExpression = taskParameters.getInfo();
     return taskTemplate.execute(TaskContext.builder()
         .labels(taskParameters.getLabelSelector() != null ? taskParameters.getLabelSelector().entrySet() : null)
-        .alertId(taskIdGenerator.generateAlertId(tenantId, measurement, taskParameters.getCritical().getExpression().getField()))
+        .alertId(String.join(":",
+            "{{ .TaskName }}",
+            "{{ .Group }}"
+            ))
         .labelsAvailable(labelsAvailable)
         .measurement(measurement)
         .details("task={{.TaskName}}")

--- a/src/main/resources/templates/task.mustache
+++ b/src/main/resources/templates/task.mustache
@@ -14,13 +14,17 @@ stream
     {{/-last}}
   {{/labels}}
 {{/labelsAvailable}}
+{{#critExpression}}
   |stateCount(lambda: {{critExpression}})
+    .as('crit_count')
+{{/critExpression}}
 {{#warnExpression}}
   |stateCount(lambda: {{warnExpression}})
     .as('warn_count')
 {{/warnExpression}}
 {{#infoExpression}}
-  |stateCount(lambda: {{infoExpression}}).as("info_count")
+  |stateCount(lambda: {{infoExpression}})
+    .as('info_count')
 {{/infoExpression}}
   |alert()
     .stateChangesOnly()
@@ -32,5 +36,7 @@ stream
 {{#warnCount}}
     .warn(lambda: {{warnCount}})
 {{/warnCount}}
+{{#critCount}}
     .crit(lambda: {{critCount}})
+{{/critCount}}
     .topic('events')

--- a/src/main/resources/templates/task.mustache
+++ b/src/main/resources/templates/task.mustache
@@ -15,6 +15,13 @@ stream
   {{/labels}}
 {{/labelsAvailable}}
   |stateCount(lambda: {{critExpression}})
+{{#warnExpression}}
+  |stateCount(lambda: {{warnExpression}})
+    .as('warn_count')
+{{/warnExpression}}
+{{#infoExpression}}
+  |stateCount(lambda: {{infoExpression}}).as("info_count")
+{{/infoExpression}}
   |alert()
     .stateChangesOnly()
     .id('{{alertId}}')


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-192 specifically the different levels of thresholds portion

# What

Customers might want different expressions for different levels of alarming. This is a proposal for altering the TaskParameters to store the expressions for each different level so that we can setup StateCount expressions for each of them. 

# How

It creates a new Expression object and then creates a number of levelExpressions that contain the consecutive count that correspond to the different levels that we expect. 

# Why

This is meant as a proposal. The objects encapsulate the functionality we need. It is inefficient in the sense that it doesn't allow for one base expression and then all of the sub expressions to use the consecutive count from that. 

It does however make the template easier. We can create new StateCount nodes for each level giving each one a different name with the `.as("warningLevel")` function which then allows us to create a single alarm and then add the lambdas that strictly reference those StateCount's. 

## How to test

This isn't even built into the template yet and shouldn't work because of data type changes that haven't been propogated to TickScriptBuilder yet.

# TODO
Update the tests