### PR TITLE
Allow api fields to be allowed by default

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: salus-event-engine-management
+  jackson:
+    mapper:
+      default-view-inclusion: true


### PR DESCRIPTION
Without this the `JsonViews` annotated endpoints will not return any non-annotated fields as default.

Since we are leaving "public" response fields without annotations and only annotating "internal" or "admin" fields, we must include this option.