### PR TITLE
Add timestamps to events + some cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,12 @@
       <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.co.jemos.podam</groupId>
+      <artifactId>podam</artifactId>
+      <version>7.2.1.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/rackspace/salus/event/manage/entities/EventEngineTask.java
+++ b/src/main/java/com/rackspace/salus/event/manage/entities/EventEngineTask.java
@@ -16,16 +16,21 @@
 
 package com.rackspace.salus.event.manage.entities;
 
+import com.rackspace.salus.event.manage.model.EventEngineTaskDTO;
 import com.rackspace.salus.event.manage.model.TaskParameters;
 import com.vladmihalcea.hibernate.type.json.JsonStringType;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.UUID;
 import javax.persistence.*;
 
 import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(
@@ -45,6 +50,9 @@ public class EventEngineTask {
   String tenantId;
 
   @Column(nullable = false)
+  String name;
+
+  @Column(nullable = false)
   String measurement;
 
   @Column(nullable = false)
@@ -54,11 +62,23 @@ public class EventEngineTask {
   @Column(nullable = false, columnDefinition = "json")
   TaskParameters taskParameters;
 
-  /**
-   * Labels are an indexed and query'able aspect of resources that are used for event task
-   * matching.
-   */
-  @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(name="event_engine_task_label_selector", joinColumns = @JoinColumn(name="id"))
-  Map<String,String> labelSelector;
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+
+  public EventEngineTaskDTO toDTO() {
+    return new EventEngineTaskDTO()
+        .setId(id)
+        .setTenantId(tenantId)
+        .setTaskId(taskId)
+        .setName(name)
+        .setMeasurement(measurement)
+        .setTaskParameters(taskParameters)
+        .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(createdTimestamp))
+        .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(updatedTimestamp));
+  }
 }

--- a/src/main/java/com/rackspace/salus/event/manage/model/EventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/EventEngineTaskDTO.java
@@ -17,14 +17,22 @@
 package com.rackspace.salus.event.manage.model;
 
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.salus.telemetry.model.View;
 import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class EventEngineTaskDTO {
   UUID id;
+
+  @JsonView(View.Admin.class)
   String tenantId;
+
+  String name;
   String measurement;
-  String label;
+  String taskId;
   TaskParameters taskParameters;
+  String createdTimestamp;
+  String updatedTimestamp;
 }

--- a/src/main/java/com/rackspace/salus/event/manage/web/TasksApi.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/TasksApi.java
@@ -79,7 +79,7 @@ public class TasksApi {
 
     return PagedContent.fromPage(
         tasksService.getTasks(tenantId, pageable)
-            .map(eventEngineTask -> objectMapper.convertValue(eventEngineTask, EventEngineTaskDTO.class)));
+            .map(EventEngineTask::toDTO));
   }
 
   @DeleteMapping("/tenant/{tenantId}/tasks/{taskId}")

--- a/src/test/java/com/rackspace/salus/event/manage/model/EventEngineTaskDTOTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/model/EventEngineTaskDTOTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.model;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.event.manage.entities.EventEngineTask;
+import com.rackspace.salus.telemetry.model.View;
+import org.junit.Test;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+public class EventEngineTaskDTOTest {
+  final PodamFactory podamFactory = new PodamFactoryImpl();
+
+  final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testFieldsCovered() throws Exception {
+    final EventEngineTask task = podamFactory.manufacturePojo(EventEngineTask.class);
+
+    final EventEngineTaskDTO dto = task.toDTO();
+
+    assertThat(dto.getId(), notNullValue());
+    assertThat(dto.getTenantId(), notNullValue());
+    assertThat(dto.getTaskId(), notNullValue());
+    assertThat(dto.getName(), notNullValue());
+    assertThat(dto.getMeasurement(), notNullValue());
+    assertThat(dto.getTaskParameters(), notNullValue());
+    assertThat(dto.getCreatedTimestamp(), notNullValue());
+    assertThat(dto.getUpdatedTimestamp(), notNullValue());
+
+    assertThat(dto.getId(), equalTo(task.getId()));
+    assertThat(dto.getTenantId(), equalTo(task.getTenantId()));
+    assertThat(dto.getTaskId(), equalTo(task.getTaskId()));
+    assertThat(dto.getName(), equalTo(task.getName()));
+    assertThat(dto.getMeasurement(), equalTo(task.getMeasurement()));
+    assertThat(dto.getTaskParameters(), equalTo(task.getTaskParameters()));
+    assertThat(dto.getCreatedTimestamp(), equalTo(task.getCreatedTimestamp().toString()));
+    assertThat(dto.getUpdatedTimestamp(), equalTo(task.getUpdatedTimestamp().toString()));
+
+    String objectAsString;
+    EventEngineTaskDTO convertedDto;
+
+    objectAsString = objectMapper.writerWithView(View.Public.class).writeValueAsString(dto);
+    convertedDto = objectMapper.readValue(objectAsString, EventEngineTaskDTO.class);
+    assertThat(convertedDto.getTenantId(), nullValue());
+
+    objectAsString = objectMapper.writerWithView(View.Admin.class).writeValueAsString(dto);
+    convertedDto = objectMapper.readValue(objectAsString, EventEngineTaskDTO.class);
+    assertThat(convertedDto.getTenantId(), notNullValue());
+
+    objectAsString = objectMapper.writerWithView(View.Internal.class).writeValueAsString(dto);
+    convertedDto = objectMapper.readValue(objectAsString, EventEngineTaskDTO.class);
+    assertThat(convertedDto.getTenantId(), nullValue());
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-422

# What

Adds create/update timestamps.
Cleans up some old things.

# How

Adds a `toDTO` method to correctly convert from Instant to the timestamp format we want.  Also ensures the right fields are being converted and nothing we care about gets excluded like what may have been happening with the objectmapper.

## How to test

Run tests.
Run locally.

# Why

Everything that can be created/updated should have a timestamp.