### PR TITLE
fix isPresent() clause

### DIFF
--- a/src/main/resources/templates/task.mustache
+++ b/src/main/resources/templates/task.mustache
@@ -18,7 +18,7 @@ stream
 {{#labelsAvailable}}
   |where(lambda:
   {{#labels}}
-    if(isPresent("{{key}}"), "{{key}}" == '{{value}}', FALSE)
+    isPresent("{{key}}") AND ("{{key}}" == '{{value}}')
     {{^-last}}
       AND
     {{/-last}}

--- a/src/test/resources/TickScriptBuilderTest/testBuild.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuild.tick
@@ -3,7 +3,7 @@ stream
     .measurement('measurement')
     .groupBy('system_resource_id')
   |where(lambda:
-    if(isPresent("resource_metadata_os"), "resource_metadata_os" == 'linux', FALSE)
+    isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )
   |stateDuration(lambda: "field" > 33)
     .unit(1m)

--- a/src/test/resources/TickScriptBuilderTest/testBuildMultipleExpressions.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildMultipleExpressions.tick
@@ -3,7 +3,7 @@ stream
     .measurement('measurement')
     .groupBy('system_resource_id')
   |where(lambda:
-    if(isPresent("resource_metadata_os"), "resource_metadata_os" == 'linux', FALSE)
+    isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )
   |stateDuration(lambda: "field" > 33)
     .unit(1m)

--- a/src/test/resources/TickScriptBuilderTest/testBuildMultipleLabels.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildMultipleLabels.tick
@@ -3,9 +3,9 @@ stream
     .measurement('measurement')
     .groupBy('system_resource_id')
   |where(lambda:
-    if(isPresent("resource_metadata_env"), "resource_metadata_env" == 'prod', FALSE)
+    isPresent("resource_metadata_env") AND ("resource_metadata_env" == 'prod')
       AND
-    if(isPresent("resource_metadata_os"), "resource_metadata_os" == 'linux', FALSE)
+    isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )
   |stateDuration(lambda: "field" > 33)
     .unit(1m)

--- a/src/test/resources/TickScriptBuilderTest/testBuildOnlyInfo.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildOnlyInfo.tick
@@ -3,7 +3,7 @@ stream
     .measurement('measurement')
     .groupBy('system_resource_id')
   |where(lambda:
-    if(isPresent("resource_metadata_os"), "resource_metadata_os" == 'linux', FALSE)
+    isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )
   |stateDuration(lambda: "field" > 33)
     .unit(1m)

--- a/src/test/resources/TickScriptBuilderTest/testBuildOnlyWarning.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildOnlyWarning.tick
@@ -3,7 +3,7 @@ stream
     .measurement('measurement')
     .groupBy('system_resource_id')
   |where(lambda:
-    if(isPresent("resource_metadata_os"), "resource_metadata_os" == 'linux', FALSE)
+    isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )
   |stateDuration(lambda: "field" >= 33)
       .unit(1m)


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-665

# What

The kapacitor logs have a lot of extra error messages:
```
ts=2019-10-23T20:36:02.004Z lvl=error msg="error while evaluating expression" service=kapacitor task_master=main task=923886-net_response-e950af46-027b-4879-965e-914a3b364222 node=where2 err="Failed to handle 2 argument: left reference value \"agent_discovered_os\" is missing value"
```


It's caused by this line in the mustache template:
```
    if(isPresent("{{key}}"), "{{key}}" == '{{value}}', FALSE)
```
The problem appears to be that 'if' is a function, and all its parameters are evaluated before it is invoked, so even though the if test fails, and doesn't return the second parameter, the error message still gets generated.



The fix is to not call if() but rather use the short circuiting built into the AND operator, like so:
```
    isPresent("{{key}}") AND ("{{key}}" == '{{value}}')
```
