### PR TITLE
Add equals operator to tasks

### DIFF
--- a/src/test/java/com/rackspace/salus/event/manage/model/ExpressionValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/model/ExpressionValidatorTest.java
@@ -83,6 +83,42 @@ public class ExpressionValidatorTest {
   }
 
   @Test
+  public void testValidation_notEqual() {
+
+    final Expression resource = new Expression()
+        .setComparator("!=")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
+  public void testValidation_regex() {
+
+    final Expression resource = new Expression()
+        .setComparator("=~")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
+  public void testValidation_notRegex() {
+
+    final Expression resource = new Expression()
+        .setComparator("!~")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
   public void testValidation_failure() {
 
     final Expression resource = new Expression()
@@ -94,7 +130,8 @@ public class ExpressionValidatorTest {
     assertThat(results.size(), equalTo(1));
     final ConstraintViolation<Expression> violation = results.iterator().next();
     assertThat(violation.getPropertyPath().toString(), equalTo("comparator"));
-    assertThat(violation.getMessage(), equalTo("Valid comparators are: ==, >, >=, <, <="));
+    assertThat(violation.getMessage(),
+        equalTo("Valid comparators are: ==, !=, >, >=, <, <=, =~, !~"));
   }
 
   @Test
@@ -109,7 +146,8 @@ public class ExpressionValidatorTest {
     assertThat(results.size(), equalTo(1));
     final ConstraintViolation<Expression> violation = results.iterator().next();
     assertThat(violation.getPropertyPath().toString(), equalTo("comparator"));
-    assertThat(violation.getMessage(), equalTo("Valid comparators are: ==, >, >=, <, <="));
+    assertThat(violation.getMessage(),
+        equalTo("Valid comparators are: ==, !=, >, >=, <, <=, =~, !~"));
   }
 
 }

--- a/src/test/java/com/rackspace/salus/event/manage/model/ExpressionValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/model/ExpressionValidatorTest.java
@@ -23,10 +23,58 @@ public class ExpressionValidatorTest {
 
 
   @Test
-  public void testValidation_normal() {
+  public void testValidation_equals() {
+
+    final Expression resource = new Expression()
+        .setComparator("==")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
+  public void testValidation_greaterEquals() {
+
+    final Expression resource = new Expression()
+        .setComparator(">=")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
+  public void testValidation_lessEquals() {
+
+    final Expression resource = new Expression()
+        .setComparator("<=")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
+  public void testValidation_greater() {
 
     final Expression resource = new Expression()
         .setComparator(">")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results, equalTo(Collections.emptySet()));
+  }
+
+  @Test
+  public void testValidation_less() {
+
+    final Expression resource = new Expression()
+        .setComparator("<")
         .setField("used")
         .setThreshold(33);
     final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
@@ -46,7 +94,22 @@ public class ExpressionValidatorTest {
     assertThat(results.size(), equalTo(1));
     final ConstraintViolation<Expression> violation = results.iterator().next();
     assertThat(violation.getPropertyPath().toString(), equalTo("comparator"));
-    assertThat(violation.getMessage(), equalTo("Valid comparators are: >, >=, <, <="));
+    assertThat(violation.getMessage(), equalTo("Valid comparators are: ==, >, >=, <, <="));
+  }
+
+  @Test
+  public void testValidation_failure2() {
+
+    final Expression resource = new Expression()
+        .setComparator("=")
+        .setField("used")
+        .setThreshold(33);
+    final Set<ConstraintViolation<Expression>> results = validatorFactoryBean.validate(resource);
+
+    assertThat(results.size(), equalTo(1));
+    final ConstraintViolation<Expression> violation = results.iterator().next();
+    assertThat(violation.getPropertyPath().toString(), equalTo("comparator"));
+    assertThat(violation.getMessage(), equalTo("Valid comparators are: ==, >, >=, <, <="));
   }
 
 }


### PR DESCRIPTION
# What

Adds the ability to use `==` in task criteria

# How

Add the enum

From https://docs.influxdata.com/kapacitor/v1.5/tick/expr/
> The comparison operator for equality is == not =.

## How to test

Added some more tests and verified manually that kapacitor accepts the new payload.

# Why

I was looking through the event engine and saw this was an easy thing to add in.  It's especially useful for string metrics or integers that don't change much.
