### PR TITLE
Enable role based json views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-sleuth</artifactId>
     </dependency>
@@ -75,20 +79,6 @@
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-common</artifactId>
       <version>0.1.0-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>spring-boot-starter-security</artifactId>
-          <groupId>org.springframework.boot</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-boot-starter-web</artifactId>
-          <groupId>org.springframework.boot</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jetcd-core</artifactId>
-          <groupId>com.coreos</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/rackspace/salus/event/manage/EventEngineManageApplication.java
+++ b/src/main/java/com/rackspace/salus/event/manage/EventEngineManageApplication.java
@@ -17,17 +17,17 @@
 package com.rackspace.salus.event.manage;
 
 import com.rackspace.salus.common.util.DumpConfigProperties;
-import com.rackspace.salus.common.web.ExtendedErrorAttributesConfig;
+import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
+import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
 import com.rackspace.salus.event.discovery.DiscoveryServiceModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import({
-    DiscoveryServiceModule.class,
-    ExtendedErrorAttributesConfig.class
-})
+@EnableRoleBasedJsonViews
+@EnableExtendedErrorAttributes
+@Import(DiscoveryServiceModule.class)
 public class EventEngineManageApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/event/manage/web/controller/TasksApiController.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/controller/TasksApiController.java
@@ -23,7 +23,7 @@ import com.rackspace.salus.event.manage.services.TasksService;
 import com.rackspace.salus.event.manage.web.model.EventEngineTaskDTO;
 import com.rackspace.salus.telemetry.entities.EventEngineTask;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -70,7 +70,6 @@ public class TasksApiController {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates Task for Tenant")
   @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Task")})
-  @JsonView(View.Public.class)
   public EventEngineTaskDTO createTask(@PathVariable String tenantId,
                                        @RequestBody @Validated CreateTask task) {
     final EventEngineTask eventEngineTask = tasksService.createTask(tenantId, task);
@@ -80,7 +79,6 @@ public class TasksApiController {
 
   @GetMapping("/tenant/{tenantId}/tasks")
   @ApiOperation(value = "Gets all Tasks for the specific Tenant")
-  @JsonView(View.Public.class)
   public PagedContent<EventEngineTaskDTO> getTasks(@PathVariable String tenantId, Pageable pageable) {
 
     return PagedContent.fromPage(
@@ -92,7 +90,6 @@ public class TasksApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes Task for Tenant")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Task Deleted")})
-  @JsonView(View.Public.class)
   public void deleteTask(@PathVariable String tenantId,
                          @PathVariable UUID taskId) {
     tasksService.deleteTask(tenantId, taskId);

--- a/src/main/java/com/rackspace/salus/event/manage/web/controller/TasksApiController.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/controller/TasksApiController.java
@@ -16,14 +16,12 @@
 
 package com.rackspace.salus.event.manage.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.event.manage.model.CreateTask;
 import com.rackspace.salus.event.manage.services.TasksService;
 import com.rackspace.salus.event.manage.web.model.EventEngineTaskDTO;
 import com.rackspace.salus.telemetry.entities.EventEngineTask;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;

--- a/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
@@ -20,7 +20,7 @@ package com.rackspace.salus.event.manage.web.model;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.EventEngineTask;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import lombok.Data;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,12 +2,22 @@
 logging:
   level:
     com.rackspace.salus.event.manage: debug
-salus.event:
-  discovery:
-    port-strategy:
-      host: localhost
-      starting-port: 9192
-      partitions: 2
+salus:
+  event:
+    discovery:
+      port-strategy:
+        host: localhost
+        starting-port: 9192
+        partitions: 2
+  common:
+    roles:
+      role-to-view:
+        # An anonymous role is used for unauthenticated requests.
+        # i.e. internal service-to-service requests.
+        ROLE_ANONYMOUS: ADMIN
+        ROLE_CUSTOMER: PUBLIC
+        ROLE_EMPLOYEE: INTERNAL
+        ROLE_ENGINEER: ADMIN
 server:
   port: 8087
 spring:

--- a/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.telemetry.entities.EventEngineTask;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import org.junit.Test;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;


### PR DESCRIPTION
# What

Enable role based json views instead of endpoint driven views.

# How

1. Add `@EnableRoleBasedJsonViews` to app
   * https://github.com/racker/salus-common/pull/49
1. Remove `@JsonView` annotations on api controllers
1. Add default role mappings to `application-dev.yml`

# Why

See https://github.com/racker/salus-common/pull/49
