### PR TITLE
Enable tenant id verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,18 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
     </dependency>

--- a/src/main/java/com/rackspace/salus/event/manage/EventEngineManageApplication.java
+++ b/src/main/java/com/rackspace/salus/event/manage/EventEngineManageApplication.java
@@ -16,10 +16,12 @@
 
 package com.rackspace.salus.event.manage;
 
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
 import com.rackspace.salus.event.discovery.DiscoveryServiceModule;
+import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
@@ -27,6 +29,8 @@ import org.springframework.context.annotation.Import;
 @SpringBootApplication
 @EnableRoleBasedJsonViews
 @EnableExtendedErrorAttributes
+@EnableTenantVerification
+@AutoConfigureSalusAppMetrics
 @Import(DiscoveryServiceModule.class)
 public class EventEngineManageApplication {
 

--- a/src/main/java/com/rackspace/salus/event/manage/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/controller/RestExceptionHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.web.controller;
+
+import com.rackspace.salus.common.web.AbstractRestExceptionHandler;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ControllerAdvice(basePackages = "com.rackspace.salus.event.manage.web")
+@ResponseBody
+public class RestExceptionHandler extends AbstractRestExceptionHandler {
+
+  @Autowired
+  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+    super(errorAttributes);
+  }
+
+  @ExceptionHandler({NotFoundException.class})
+  public ResponseEntity<?> handleNotFound(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.NOT_FOUND);
+  }
+}


### PR DESCRIPTION
See https://github.com/racker/salus-telemetry-model/pull/124

Utilizes the `@EnableTenantVerification` annotations and adds some simple tests to show it took effect.