### PR TITLE
Adam/upload api docs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,4 +51,9 @@ steps:
     volumes:
     - name: user.home
       path: /root
+artifacts:
+  objects:
+    location: 'gs://salus_www/agent_catalog_management/'
+    paths: ['target/generated/swagger/converted.html']
+
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
       path: /root
 artifacts:
   objects:
-    location: 'gs://salus_www/agent_catalog_management/'
+    location: 'gs://salus_www/event_engine_management/'
     paths: ['target/generated/swagger/converted.html']
 
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-882

# What

It is making sure that when we build this project that the API docs are hosted in a Google Cloud Storage bucket so that we may reference them. 

# How

Utilizes the Google Cloud build system to upload specific artifacts to a specific cloud storage location. Every build should overwrite the previous file.

## How to test

Check the bucket after a build

# Why

Because we are already using Google Cloud Build to do everything and this seemed like an excellent option till we can integrate fully with the documentation team.