### PR TITLE
Adam/task id fix

### DIFF
--- a/src/main/java/com/rackspace/salus/event/manage/services/KapacitorTaskIdGenerator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/KapacitorTaskIdGenerator.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class KapacitorTaskIdGenerator {
+  private static final String UNDERSCORE = "_";
+  private static final String COLON = ":";
 
   @Data
   public static class KapacitorTaskId {
@@ -33,7 +35,7 @@ public class KapacitorTaskIdGenerator {
     final KapacitorTaskId taskId = new KapacitorTaskId()
         .setBaseId(UUID.randomUUID());
     taskId.setKapacitorTaskId(String.format("%s-%s-%s",
-        tenantId.replace(":", "_"), collectionName, taskId.getBaseId().toString()
+        tenantId.replace(COLON, UNDERSCORE), collectionName, taskId.getBaseId().toString()
     ));
 
     return taskId;

--- a/src/main/java/com/rackspace/salus/event/manage/services/KapacitorTaskIdGenerator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/KapacitorTaskIdGenerator.java
@@ -33,15 +33,9 @@ public class KapacitorTaskIdGenerator {
     final KapacitorTaskId taskId = new KapacitorTaskId()
         .setBaseId(UUID.randomUUID());
     taskId.setKapacitorTaskId(String.format("%s-%s-%s",
-        tenantId, collectionName, taskId.getBaseId().toString()
+        tenantId.replace(":", "_"), collectionName, taskId.getBaseId().toString()
     ));
 
     return taskId;
   }
-
-  public String pattern(String tenantId) {
-    return String.format("%s-*", tenantId);
-  }
-
-
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-884

# What

This PR is making sure that we can create Tasks for "hybrid:xxxxxx" style tenants

# How

It alters how we are generating the taskId so that we don't use restricted characters

## How to test

The only way to test this is to send the completed script to Kapacitor and have it tell us what is and isn't restricted. We don't have that capability in any of our current unit tests.

The best way to test this is to start this app and create a task with the "hybrid:xxxxxx" tenant id. 

# Why

I have attempted to look at Kapacitor to see if there is a better way to alter restricted characters within the task id but haven't been able to find anything. Short of altering the kapacitor config itself the only thing we can do is alter our id generation methods.
