### PR TITLE
Bump swagger version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-core</artifactId>
-      <version>1.5.6</version>
+      <version>1.6.2</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>


### PR DESCRIPTION
# What

Use the newest v1 swagger version.  They also have a version 2.1.3 version which was released prior to 1.6.2, but I'm assuming it might have breaking changes.  I didn't look too hard.

## How to test

Swagger parts complete when doing a `mvn install`.

# Why

Builds were failing due to this reason
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:java (default) on project salus-event-engine-management: An exception occured while executing the Java class. null: InvocationTargetException: class java.lang.Double cannot be cast to class java.math.BigDecimal (java.lang.Double and java.math.BigDecimal are in module java.base of loader 'bootstrap') (through reference chain: io.swagger.models.ModelImpl["properties"]->java.util.LinkedHashMap["criticalStateDuration"]) (through reference chain: io.swagger.models.Swagger["definitions"]->java.util.LinkedHashMap["EventEngineTaskParameters"]) -> [Help 1]
```