### PR TITLE
Use monitor and zone fields to distinguish between tasks

### DIFF
--- a/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
@@ -250,7 +250,7 @@ public class TickScriptBuilder {
     @Default
     String details = "";
     @Default
-    String groupBy = Tags.RESOURCE_ID;
+    List<String> groupBy = List.of(Tags.RESOURCE_ID, Tags.MONITOR_ID, Tags.MONITORING_ZONE);
     String joinedEvals;
     String joinedAs;
     DerivativeNode derivative;

--- a/src/main/resources/templates/task.mustache
+++ b/src/main/resources/templates/task.mustache
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('{{measurement}}')
-    .groupBy('{{groupBy}}')
+    .groupBy({{#groupBy}}'{{this}}'{{^-last}}, {{/-last}}{{/groupBy}})
 {{#labelsAvailable}}
   |where(lambda:
   {{#labels}}

--- a/src/test/resources/TickScriptBuilderTest/testBuildBasicEvalNode.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildBasicEvalNode.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |eval(lambda: 1.0 + "field" + sigma("cpu", 1), lambda: 2.0 - "tag" - count("field2", 1))
     .as('as1', 'as2')
     .keep()

--- a/src/test/resources/TickScriptBuilderTest/testBuildBooleanThreshold.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildBooleanThreshold.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildComplexExpression.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildComplexExpression.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('new_measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildDerivativeNode.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildDerivativeNode.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |derivative('metric')
     .unit(1m)
     .as('rate_metric')

--- a/src/test/resources/TickScriptBuilderTest/testBuildMultipleExpressions.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildMultipleExpressions.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildMultipleLabels.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildMultipleLabels.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_env") AND ("resource_metadata_env" == 'prod')
       AND

--- a/src/test/resources/TickScriptBuilderTest/testBuildNoLabels.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildNoLabels.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |stateDuration(lambda: ("field" > 33))
     .unit(1m)
     .as('crit_count')

--- a/src/test/resources/TickScriptBuilderTest/testBuildNumberThreshold.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildNumberThreshold.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildOnlyInfo.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildOnlyInfo.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildOnlyWarning.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildOnlyWarning.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildPercentNode.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildPercentNode.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |eval(lambda: (float("metric1") / float("metric2")) * 100.0)
     .as('percentage')
     .keep()

--- a/src/test/resources/TickScriptBuilderTest/testBuildStringThreshold.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildStringThreshold.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_os") AND ("resource_metadata_os" == 'linux')
       )

--- a/src/test/resources/TickScriptBuilderTest/testBuildWindow.tick
+++ b/src/test/resources/TickScriptBuilderTest/testBuildWindow.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |window()
     .period(8m)
     .every(8m)

--- a/src/test/resources/TickScriptBuilderTest/testNullConsecutiveCount.tick
+++ b/src/test/resources/TickScriptBuilderTest/testNullConsecutiveCount.tick
@@ -1,7 +1,7 @@
 stream
   |from()
     .measurement('measurement')
-    .groupBy('system_resource_id')
+    .groupBy('system_resource_id', 'system_monitor_id', 'system_monitoring_zone')
   |where(lambda:
     isPresent("resource_metadata_env") AND ("resource_metadata_env" == 'prod')
       AND


### PR DESCRIPTION
# What

Add monitoring zone and monitor id to all tasks groupBy functions.

## How to test

Updated existing tests and I also tried this with [kapacitor-unit](https://github.com/gpestana/kapacitor-unit) and it seems to work fine for agent measurements that wont have a zone set.

# Why

Each bound monitor per resource should be evaluated individually.  The results for each monitor:resource will then be combined to determine if it should generate a "notification".

# TODO

Probably create a kafka streams app to do the grouping/notify things.

I played around with using `combine`, `cumulativeSum`, `flatten` etc. in the tick script but nothing seems to fully solve our use-case, which is why a separate app will be needed.