### PR TITLE
Renamed event task expression field from metricName to valueName

### DIFF
--- a/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TickScriptBuilder.java
@@ -156,7 +156,7 @@ public class TickScriptBuilder {
 
   private String buildTICKExpression(ComparisonExpression expression) {
     StringBuilder tickExpression = new StringBuilder("(");
-    tickExpression.append("\"").append(expression.getMetricName()).append("\"");
+    tickExpression.append("\"").append(expression.getValueName()).append("\"");
     tickExpression.append(" ");
     tickExpression.append(expression.getComparator().getFriendlyName());
     tickExpression.append(" ");

--- a/src/test/java/com/rackspace/salus/event/manage/services/TasksServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TasksServiceTest.java
@@ -499,7 +499,7 @@ public class TasksServiceTest {
                     new StateExpression()
                         .setExpression(
                             new ComparisonExpression()
-                                .setMetricName("usage_user")
+                                .setValueName("usage_user")
                                 .setComparator(Comparator.GREATER_THAN)
                                 .setComparisonValue(75)
                         )

--- a/src/test/java/com/rackspace/salus/event/manage/services/TestEventTaskServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TestEventTaskServiceTest.java
@@ -591,7 +591,7 @@ public class TestEventTaskServiceTest {
                             new StateExpression()
                                 .setExpression(
                                     new ComparisonExpression()
-                                        .setMetricName("usage")
+                                        .setValueName("usage")
                                         .setComparator(Comparator.GREATER_THAN)
                                         .setComparisonValue(80)
                                 )

--- a/src/test/java/com/rackspace/salus/event/manage/services/TickScriptBuilderTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TickScriptBuilderTest.java
@@ -59,7 +59,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildNumberThreshold.tick");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(0);
 
@@ -84,7 +84,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildStringThreshold.tick");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("code")
+        .setValueName("code")
         .setComparator(Comparator.NOT_REGEX_MATCH)
         .setComparisonValue("true");
 
@@ -109,7 +109,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildBooleanThreshold.tick");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.EQUAL_TO)
         .setComparisonValue(true);
 
@@ -134,7 +134,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildOnlyInfo.tick");
 
     ComparisonExpression infoExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(33);
 
@@ -160,7 +160,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildNoStateChangesOnly.tick");
 
     ComparisonExpression infoExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(33);
 
@@ -191,26 +191,26 @@ public class TickScriptBuilderTest {
         .setOperator(Operator.OR)
         .setExpressions(List.of(
             new ComparisonExpression()
-                .setMetricName("field")
+                .setValueName("field")
                 .setComparator(Comparator.GREATER_THAN)
                 .setComparisonValue(33),
             new ComparisonExpression()
-                .setMetricName("test")
+                .setValueName("test")
                 .setComparator(Comparator.LESS_THAN_OR_EQUAL_TO)
                 .setComparisonValue(17)));
 
     ComparisonExpression critExpressionComp = new ComparisonExpression()
-        .setMetricName("new_field")
+        .setValueName("new_field")
         .setComparator(Comparator.REGEX_MATCH)
         .setComparisonValue("my_value");
 
     ComparisonExpression warnExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(30);
 
     ComparisonExpression infoExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(20);
 
@@ -250,7 +250,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildNoLabels.tick");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(33);
 
@@ -272,7 +272,7 @@ public class TickScriptBuilderTest {
     String expectedString = readContent("/TickScriptBuilderTest/testBuildNoLabels.tick");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(33);
 
@@ -298,7 +298,7 @@ public class TickScriptBuilderTest {
     labelSelectors.put("resource_metadata_env", "prod");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(33);
 
@@ -383,7 +383,7 @@ public class TickScriptBuilderTest {
     labelSelectors.put("resource_metadata_env", "prod");
 
     ComparisonExpression critExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(33);
 
@@ -413,31 +413,31 @@ public class TickScriptBuilderTest {
         .setOperator(Operator.AND)
         .setExpressions(List.of(
             new ComparisonExpression()
-                .setMetricName("field")
+                .setValueName("field")
                 .setComparator(Comparator.GREATER_THAN)
                 .setComparisonValue(33),
             new ComparisonExpression()
-                .setMetricName("test")
+                .setValueName("test")
                 .setComparator(Comparator.NOT_EQUAL_TO)
                 .setComparisonValue(17)));
 
     ComparisonExpression critExpressionComp = new ComparisonExpression()
-        .setMetricName("new_field")
+        .setValueName("new_field")
         .setComparator(Comparator.REGEX_MATCH)
         .setComparisonValue("my_value");
 
     ComparisonExpression warnExpression1 = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(30);
 
     ComparisonExpression warnExpression2 = new ComparisonExpression()
-        .setMetricName("false")
+        .setValueName("false")
         .setComparator(Comparator.EQUAL_TO)
         .setComparisonValue(false);
 
     ComparisonExpression infoExpression = new ComparisonExpression()
-        .setMetricName("field")
+        .setValueName("field")
         .setComparator(Comparator.GREATER_THAN)
         .setComparisonValue(20);
 

--- a/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
@@ -511,7 +511,7 @@ public class TasksApiControllerTest {
                     new StateExpression()
                         .setExpression(
                             new ComparisonExpression()
-                                .setMetricName("usage_user")
+                                .setValueName("usage_user")
                                 .setComparator(Comparator.GREATER_THAN)
                                 .setComparisonValue(75)
                         )
@@ -548,11 +548,11 @@ public class TasksApiControllerTest {
                         .setOperator(Operator.OR)
                         .setExpressions(List.of(
                                     new ComparisonExpression()
-                                        .setMetricName("usage_user")
+                                        .setValueName("usage_user")
                                         .setComparator(Comparator.GREATER_THAN)
                                         .setComparisonValue(75),
                                     new ComparisonExpression()
-                                        .setMetricName("usage_system")
+                                        .setValueName("usage_system")
                                         .setComparator(Comparator.EQUAL_TO)
                                         .setComparisonValue(92)))
                         )

--- a/src/test/resources/TasksControllerTest/get_task_response.json
+++ b/src/test/resources/TasksControllerTest/get_task_response.json
@@ -17,13 +17,13 @@
             {
               "type": "comparison",
               "comparator": ">",
-              "metricName": "usage_user",
+              "valueName": "usage_user",
               "comparisonValue": 75
             },
             {
               "type": "comparison",
               "comparator": "==",
-              "metricName": "usage_system",
+              "valueName": "usage_system",
               "comparisonValue": 92
             }
           ]


### PR DESCRIPTION
# What

When looking at the end to end context of the test-monitor -> test-event-task it was confusing to see "metricName" in the task expression since the overall object is `ExternalMetric`, which has a measurement/collection name and "metricName" was actually referring to one of the ivalues/fvalues/svalues entries. Renamed the property to `valueName` to align with the values maps.

# Depends on

https://github.com/racker/salus-telemetry-model/pull/144