### PR TITLE
Abstract EventTask to allow subtypes for different monitoring systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.rackspace.monplat</groupId>
+      <artifactId>umb-protocol</artifactId>
+      <version>0.3.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/src/main/java/com/rackspace/salus/event/manage/model/GenericTaskCU.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/GenericTaskCU.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.model;
+
+import com.rackspace.salus.event.manage.model.ValidationGroups.Create;
+import com.rackspace.salus.event.manage.model.ValidationGroups.Test;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class GenericTaskCU extends TaskCU {
+  @NotNull(groups = {Create.class, Test.class})
+  String measurement;
+}

--- a/src/main/java/com/rackspace/salus/event/manage/model/SalusTaskCU.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/SalusTaskCU.java
@@ -16,35 +16,20 @@
 
 package com.rackspace.salus.event.manage.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Create;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Test;
-import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
-import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
-import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
-import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-
+import lombok.EqualsAndHashCode;
 
 @Data
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "monitoringSystem")
-@JsonSubTypes({
-    @JsonSubTypes.Type(name = "salus", value= SalusEventEngineTask.class),
-    @JsonSubTypes.Type(name = "generic", value= GenericEventEngineTask.class)
-})
-public abstract class TaskCU {
-
-  @NotEmpty(groups = Create.class)
-  String name;
+@EqualsAndHashCode(callSuper = true)
+public class SalusTaskCU extends TaskCU {
+  @NotNull(groups = {Create.class, Test.class})
+  MonitorType monitorType;
 
   @NotNull(groups = {Create.class, Test.class})
-  MonitoringSystem monitoringSystem;
-
-  @NotNull(groups = {Create.class, Test.class})
-  @Valid
-  EventEngineTaskParameters taskParameters;
+  ConfigSelectorScope monitorScope;
 }

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
@@ -29,9 +29,10 @@ import lombok.Data;
 
 
 @Data
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "monitoringSystem", defaultImpl = GenericTaskCU.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+    property = "monitoringSystem", visible = true, defaultImpl = GenericTaskCU.class)
 @JsonSubTypes({
-    @JsonSubTypes.Type(name = "salus", value= SalusTaskCU.class)
+    @JsonSubTypes.Type(name = "SALUS", value= SalusTaskCU.class)
 })
 public abstract class TaskCU {
 

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
@@ -22,8 +22,6 @@ import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Create;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Test;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
-import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
-import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -31,10 +29,9 @@ import lombok.Data;
 
 
 @Data
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "monitoringSystem")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "monitoringSystem", defaultImpl = GenericTaskCU.class)
 @JsonSubTypes({
-    @JsonSubTypes.Type(name = "salus", value= SalusEventEngineTask.class),
-    @JsonSubTypes.Type(name = "generic", value= GenericEventEngineTask.class)
+    @JsonSubTypes.Type(name = "salus", value= SalusTaskCU.class)
 })
 public abstract class TaskCU {
 

--- a/src/main/java/com/rackspace/salus/event/manage/services/TaskGenerator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TaskGenerator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.services;
+
+import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
+import com.rackspace.salus.event.manage.model.GenericTaskCU;
+import com.rackspace.salus.event.manage.model.SalusTaskCU;
+import com.rackspace.salus.event.manage.model.TaskCU;
+import com.rackspace.salus.event.manage.web.model.EventEngineTaskDTO;
+import com.rackspace.salus.event.manage.web.model.GenericEventEngineTaskDTO;
+import com.rackspace.salus.event.manage.web.model.SalusEventEngineTaskDTO;
+import com.rackspace.salus.telemetry.entities.EventEngineTask;
+import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
+import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TaskGenerator {
+
+  public TaskGenerator() {
+  }
+
+  public EventEngineTask createTask(String tenantId, TaskCU in) {
+    EventEngineTask task;
+    if (in instanceof SalusTaskCU) {
+      task = createSalusTask(tenantId, (SalusTaskCU) in);
+    } else {
+      task = createGenericTask(tenantId, (GenericTaskCU) in);
+    }
+
+    return task;
+  }
+
+  private EventEngineTask createSalusTask(String tenantId, SalusTaskCU in) {
+    return new SalusEventEngineTask()
+        .setMonitorType(in.getMonitorType())
+        .setMonitorScope(in.getMonitorScope())
+        .setTenantId(tenantId)
+        .setName(in.getName())
+        .setMonitoringSystem(MonitoringSystem.SALUS.name())
+        .setTaskParameters(in.getTaskParameters());
+  }
+
+  private EventEngineTask createGenericTask(String tenantId, GenericTaskCU in) {
+    return new GenericEventEngineTask()
+        .setMeasurement(in.getMeasurement())
+        .setTenantId(tenantId)
+        .setName(in.getName())
+        .setMonitoringSystem(MonitoringSystem.SALUS.name())
+        .setTaskParameters(in.getTaskParameters());
+  }
+
+  public static EventEngineTaskDTO generateDto(EventEngineTask engineTask) {
+    if (engineTask instanceof SalusEventEngineTask) {
+      return new SalusEventEngineTaskDTO((SalusEventEngineTask) engineTask);
+    }
+    return new GenericEventEngineTaskDTO((GenericEventEngineTask) engineTask);
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
@@ -17,15 +17,26 @@
 package com.rackspace.salus.event.manage.web.model;
 
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.monplat.protocol.UniversalMetricFrame;
+import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
+import com.rackspace.salus.common.web.View;
+import com.rackspace.salus.event.manage.model.ValidationGroups.Create;
+import com.rackspace.salus.event.manage.model.ValidationGroups.Test;
 import com.rackspace.salus.telemetry.entities.EventEngineTask;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
-import com.rackspace.salus.common.web.View;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "monitoringSystem", defaultImpl = GenericEventEngineTaskDTO.class)
+@JsonSubTypes({
+    @JsonSubTypes.Type(name = "salus", value = SalusEventEngineTaskDTO.class)
+})
 @Data @NoArgsConstructor
 public abstract class EventEngineTaskDTO {
   UUID id;
@@ -38,9 +49,12 @@ public abstract class EventEngineTaskDTO {
   EventEngineTaskParameters taskParameters;
   String createdTimestamp;
   String updatedTimestamp;
+  @NotNull(groups = {Create.class, Test.class})
+  UniversalMetricFrame.MonitoringSystem monitoringSystem;
 
   public EventEngineTaskDTO(EventEngineTask entity) {
     this.id = entity.getId();
+    this.monitoringSystem = MonitoringSystem.valueOf(entity.getMonitoringSystem());
     this.tenantId = entity.getTenantId();
     this.name = entity.getName();
     this.taskParameters = entity.getTaskParameters();

--- a/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
@@ -27,7 +27,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data @NoArgsConstructor
-public class EventEngineTaskDTO {
+public abstract class EventEngineTaskDTO {
   UUID id;
 
   @JsonView(View.Admin.class)
@@ -43,7 +43,6 @@ public class EventEngineTaskDTO {
     this.id = entity.getId();
     this.tenantId = entity.getTenantId();
     this.name = entity.getName();
-    this.measurement = entity.getMeasurement();
     this.taskParameters = entity.getTaskParameters();
     this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(entity.getCreatedTimestamp());
     this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(entity.getUpdatedTimestamp());

--- a/src/main/java/com/rackspace/salus/event/manage/web/model/GenericEventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/model/GenericEventEngineTaskDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.web.model;
+
+
+import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data @NoArgsConstructor
+public class GenericEventEngineTaskDTO extends EventEngineTaskDTO {
+  String measurement;
+
+  public GenericEventEngineTaskDTO(GenericEventEngineTask entity) {
+    super(entity);
+    this.measurement = entity.getMeasurement();
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/manage/web/model/SalusEventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/model/SalusEventEngineTaskDTO.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.manage.web.model;
+
+
+import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data @NoArgsConstructor
+public class SalusEventEngineTaskDTO extends EventEngineTaskDTO {
+  MonitorType monitorType;
+  ConfigSelectorScope monitorScope;
+
+  public SalusEventEngineTaskDTO(SalusEventEngineTask entity) {
+    super(entity);
+    this.monitorType = entity.getMonitorType();
+    this.monitorScope = entity.getMonitorScope();
+  }
+}

--- a/src/test/java/com/rackspace/salus/event/manage/services/TestEventTaskServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TestEventTaskServiceTest.java
@@ -41,16 +41,16 @@ import com.rackspace.salus.event.discovery.EventEnginePicker;
 import com.rackspace.salus.event.discovery.NoPartitionsAvailableException;
 import com.rackspace.salus.event.manage.config.TestEventTaskProperties;
 import com.rackspace.salus.event.manage.errors.BackendException;
-import com.rackspace.salus.event.manage.model.TaskCU;
+import com.rackspace.salus.event.manage.model.GenericTaskCU;
 import com.rackspace.salus.event.manage.model.TestTaskRequest;
 import com.rackspace.salus.event.manage.model.TestTaskResult;
 import com.rackspace.salus.event.manage.model.TestTaskResult.TestTaskResultData.EventResult;
+import com.rackspace.salus.event.manage.services.KapacitorTaskIdGenerator.KapacitorTaskId;
 import com.rackspace.salus.event.model.kapacitor.KapacitorEvent;
 import com.rackspace.salus.event.model.kapacitor.KapacitorEvent.EventData;
 import com.rackspace.salus.event.model.kapacitor.KapacitorEvent.SeriesItem;
 import com.rackspace.salus.event.model.kapacitor.Task;
 import com.rackspace.salus.event.model.kapacitor.Task.Stats;
-import com.rackspace.salus.event.manage.services.KapacitorTaskIdGenerator.KapacitorTaskId;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.Comparator;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.ComparisonExpression;
@@ -179,7 +179,7 @@ public class TestEventTaskServiceTest {
             .setName("cpu")
             .setIvalues(Map.of("usage", 90L))
     ));
-    final String measurementName = request.getTask().getMeasurement();
+    final String measurementName = ((GenericTaskCU) request.getTask()).getMeasurement();
     final String taskId = setupKapacitorTaskId();
 
     final String expectedTaskCreate = JsonTestUtils
@@ -237,7 +237,7 @@ public class TestEventTaskServiceTest {
             .setName("cpu")
             .setIvalues(Map.of("usage", 90L))
     ));
-    final String measurementName = request.getTask().getMeasurement();
+    final String measurementName = ((GenericTaskCU) request.getTask()).getMeasurement();
     final String taskId = setupKapacitorTaskId();
 
     final String expectedTaskCreate = JsonTestUtils
@@ -304,7 +304,7 @@ public class TestEventTaskServiceTest {
             .setName("cpu")
             .setIvalues(Map.of("usage", 90L))
     ));
-    final String measurementName = request.getTask().getMeasurement();
+    final String measurementName = ((GenericTaskCU) request.getTask()).getMeasurement();
     final String taskId = setupKapacitorTaskId();
 
     final String expectedTaskCreate = JsonTestUtils
@@ -491,7 +491,7 @@ public class TestEventTaskServiceTest {
   }
 
   private void verifyTickScriptBuilder(TestTaskRequest request) {
-    verify(tickScriptBuilder).build(eq(request.getTask().getMeasurement()),
+    verify(tickScriptBuilder).build(eq(((GenericTaskCU) request.getTask()).getMeasurement()),
         argThat(params -> {
           // spot check individual parts
           assertThat(params.getStateExpressions())
@@ -581,7 +581,7 @@ public class TestEventTaskServiceTest {
   private TestTaskRequest createTestTaskRequest(List<SimpleNameTagValueMetric> metrics) {
     return new TestTaskRequest()
         .setTask(
-            new TaskCU()
+            new GenericTaskCU()
                 .setMeasurement("cpu")
                 .setTaskParameters(
                     new EventEngineTaskParameters()
@@ -621,6 +621,6 @@ public class TestEventTaskServiceTest {
   private void verifyEventEnginePicker(TestTaskRequest request)
       throws NoPartitionsAvailableException {
     verify(eventEnginePicker).pickRecipient(
-        "t-1", TestEventTaskService.PICKER_RESOURCE_ID, request.getTask().getMeasurement());
+        "t-1", TestEventTaskService.PICKER_RESOURCE_ID, ((GenericTaskCU) request.getTask()).getMeasurement());
   }
 }

--- a/src/test/java/com/rackspace/salus/event/manage/web/client/EventTaskApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/client/EventTaskApiClientTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
+import com.rackspace.salus.event.manage.model.GenericTaskCU;
 import com.rackspace.salus.event.manage.model.TestTaskRequest;
 import com.rackspace.salus.event.manage.model.TestTaskResult;
 import com.rackspace.salus.event.manage.model.TestTaskResult.TestTaskResultData;
@@ -98,7 +99,7 @@ public class EventTaskApiClientTest {
                         new EventData()
                             .setSeries(List.of(
                                 new SeriesItem()
-                                    .setName(testTaskRequest.getTask().getMeasurement())
+                                    .setName(((GenericTaskCU)testTaskRequest.getTask()).getMeasurement())
                             ))
                     )
                     .setLevel("CRITICAL")

--- a/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
@@ -40,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
 import com.rackspace.salus.event.manage.errors.TestTimedOutException;
 import com.rackspace.salus.event.manage.model.GenericTaskCU;
@@ -62,6 +63,7 @@ import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalE
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.StateExpression;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.TaskState;
 import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
+import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
 import com.rackspace.salus.telemetry.model.CustomEvalNode;
 import com.rackspace.salus.telemetry.model.DerivativeNode;
 import com.rackspace.salus.telemetry.model.MetricExpressionBase;
@@ -177,7 +179,8 @@ public class TasksApiControllerTest {
     int pageSize = 20;
     List<EventEngineTask> tasks = new ArrayList<>();
     for (int i = 0; i < numberOfTasks; i++) {
-      tasks.add(podamFactory.manufacturePojo(EventEngineTask.class));
+      tasks.add(podamFactory.manufacturePojo(SalusEventEngineTask.class)
+          .setMonitoringSystem(MonitoringSystem.SALUS.name()));
     }
 
     int start = page * pageSize;
@@ -242,7 +245,8 @@ public class TasksApiControllerTest {
 
   @Test
   public void testCreateTask() throws Exception {
-    EventEngineTask task = podamFactory.manufacturePojo(EventEngineTask.class);
+    EventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class)
+        .setMonitoringSystem(MonitoringSystem.UIM.name());
     when(tasksService.createTask(anyString(), any()))
         .thenReturn(task);
 
@@ -265,7 +269,8 @@ public class TasksApiControllerTest {
 
   @Test
   public void testUpdateTask() throws Exception {
-    EventEngineTask task = podamFactory.manufacturePojo(EventEngineTask.class);
+    EventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class)
+        .setMonitoringSystem(MonitoringSystem.MAAS.name());
     when(tasksService.updateTask(anyString(), any(), any()))
         .thenReturn(task);
 
@@ -535,6 +540,7 @@ public class TasksApiControllerTest {
       List<MetricExpressionBase> customMetrics) {
     return new GenericTaskCU()
         .setMeasurement("cpu")
+        .setMonitoringSystem(MonitoringSystem.UIM)
         .setName(setName ? "this is my name" : null)
         .setTaskParameters(
             new EventEngineTaskParameters()
@@ -565,6 +571,7 @@ public class TasksApiControllerTest {
       List<MetricExpressionBase> customMetrics) {
     return new GenericEventEngineTask()
         .setMeasurement("disk")
+        .setMonitoringSystem(MonitoringSystem.UIM.name())
         .setId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH)

--- a/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
@@ -42,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
 import com.rackspace.salus.event.manage.errors.TestTimedOutException;
+import com.rackspace.salus.event.manage.model.GenericTaskCU;
 import com.rackspace.salus.event.manage.model.TaskCU;
 import com.rackspace.salus.event.manage.model.TestTaskRequest;
 import com.rackspace.salus.event.manage.model.TestTaskResult;
@@ -60,6 +61,7 @@ import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalE
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalExpression.Operator;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.StateExpression;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.TaskState;
+import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
 import com.rackspace.salus.telemetry.model.CustomEvalNode;
 import com.rackspace.salus.telemetry.model.DerivativeNode;
 import com.rackspace.salus.telemetry.model.MetricExpressionBase;
@@ -368,6 +370,7 @@ public class TasksApiControllerTest {
   @Test
   public void testTestEventTask_normal() throws Exception {
     final String tenantId = RandomStringUtils.randomAlphabetic(8);
+    final String taskName = RandomStringUtils.randomAlphabetic(8);
 
     final TaskCU taskCU = buildCreateTask(true);
     // ...but ensure user doesn't have to name tasks being tested
@@ -376,7 +379,7 @@ public class TasksApiControllerTest {
         .setTask(taskCU)
         .setMetrics(List.of(
             podamFactory.manufacturePojo(SimpleNameTagValueMetric.class)
-                .setName(taskCU.getMeasurement())
+                .setName(taskName)
         ));
 
     final TestTaskResult expectedResult = new TestTaskResult()
@@ -386,7 +389,7 @@ public class TasksApiControllerTest {
                     new EventData()
                         .setSeries(List.of(
                             new SeriesItem()
-                                .setName(testTaskRequest.getTask().getMeasurement())
+                                .setName(taskName)
                         ))
                 )
                 .setLevel("CRITICAL"))).setStats(
@@ -411,7 +414,7 @@ public class TasksApiControllerTest {
         .andExpect(jsonPath("$.data.events[0].level",
             equalTo("CRITICAL")))
         .andExpect(jsonPath("$.data.events[0].data.series[0].name",
-            equalTo(testTaskRequest.getTask().getMeasurement())))
+            equalTo(taskName)))
         .andExpect(jsonPath("$.data.stats.node-stats.alert2.crits_triggered",
             equalTo(1)))
     ;
@@ -424,6 +427,7 @@ public class TasksApiControllerTest {
   @Test
   public void testTestEventTask_partial() throws Exception {
     final String tenantId = RandomStringUtils.randomAlphabetic(8);
+    final String taskName = RandomStringUtils.randomAlphabetic(8);
 
     final TaskCU taskCU = buildCreateTask(true);
     // ...but ensure user doesn't have to name tasks being tested
@@ -433,9 +437,9 @@ public class TasksApiControllerTest {
         .setMetrics(List.of(
             // send in two metrics
             podamFactory.manufacturePojo(SimpleNameTagValueMetric.class)
-                .setName(taskCU.getMeasurement()),
+                .setName(taskName),
             podamFactory.manufacturePojo(SimpleNameTagValueMetric.class)
-                .setName(taskCU.getMeasurement())
+                .setName(taskName)
         ));
 
     final TestTaskResult expectedResult = new TestTaskResult()
@@ -449,7 +453,7 @@ public class TasksApiControllerTest {
                         new EventData()
                             .setSeries(List.of(
                                 new SeriesItem()
-                                    .setName(testTaskRequest.getTask().getMeasurement())
+                                    .setName(taskName)
                             ))
                     )
                     .setLevel("CRITICAL")
@@ -476,7 +480,7 @@ public class TasksApiControllerTest {
         .andExpect(jsonPath("$.data.events[0].level",
             equalTo("CRITICAL")))
         .andExpect(jsonPath("$.data.events[0].data.series[0].name",
-            equalTo(testTaskRequest.getTask().getMeasurement())))
+            equalTo(taskName)))
         .andExpect(jsonPath("$.data.stats.node-stats.alert2.crits_triggered",
             equalTo(1)))
     ;
@@ -489,6 +493,7 @@ public class TasksApiControllerTest {
   @Test
   public void testTestEventTask_timedOut() throws Exception {
     final String tenantId = RandomStringUtils.randomAlphabetic(8);
+    final String taskName = RandomStringUtils.randomAlphabetic(8);
 
     final TaskCU taskCU = buildCreateTask(true);
     // ...but ensure user doesn't have to name tasks being tested
@@ -497,7 +502,7 @@ public class TasksApiControllerTest {
         .setTask(taskCU)
         .setMetrics(List.of(
             podamFactory.manufacturePojo(SimpleNameTagValueMetric.class)
-                .setName(taskCU.getMeasurement())
+                .setName(taskName)
         ));
 
     final CompletableFuture<TestTaskResult> completableFuture = new CompletableFuture<>();
@@ -528,9 +533,9 @@ public class TasksApiControllerTest {
 
   private static TaskCU buildCreateTask(boolean setName,
       List<MetricExpressionBase> customMetrics) {
-    return new TaskCU()
-        .setName(setName ? "this is my name" : null)
+    return new GenericTaskCU()
         .setMeasurement("cpu")
+        .setName(setName ? "this is my name" : null)
         .setTaskParameters(
             new EventEngineTaskParameters()
                 .setLabelSelector(
@@ -558,13 +563,13 @@ public class TasksApiControllerTest {
 
   private static EventEngineTask buildTask(String tenantId,
       List<MetricExpressionBase> customMetrics) {
-    return new EventEngineTask()
+    return new GenericEventEngineTask()
+        .setMeasurement("disk")
         .setId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH)
         .setTenantId(tenantId)
         .setName("my-test-task")
-        .setMeasurement("disk")
         .setTaskParameters(
             new EventEngineTaskParameters()
                 .setLabelSelector(

--- a/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.web.View;
-import com.rackspace.salus.telemetry.entities.EventEngineTask;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.ComparisonExpression;
+import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import uk.co.jemos.podam.api.DefaultClassInfoStrategy;
@@ -39,7 +39,7 @@ public class EventEngineTaskDTOTest {
   {
     try {
       classInfoStrategy = (DefaultClassInfoStrategy) DefaultClassInfoStrategy.getInstance()
-            .addExtraMethod(ComparisonExpression.class, "podamHelper", String.class);
+          .addExtraMethod(ComparisonExpression.class, "podamHelper", String.class);
     } catch (NoSuchMethodException e) {
       e.printStackTrace();
     }
@@ -51,9 +51,9 @@ public class EventEngineTaskDTOTest {
 
   @Test
   public void testFieldsCovered() throws Exception {
-    final EventEngineTask task = podamFactory.manufacturePojo(EventEngineTask.class);
+    final GenericEventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class);
 
-    final EventEngineTaskDTO dto = new EventEngineTaskDTO(task);
+    final EventEngineTaskDTO dto = new GenericEventEngineTaskDTO(task);
 
     assertThat(dto.getId(), notNullValue());
     assertThat(dto.getTenantId(), notNullValue());

--- a/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.ComparisonExpression;
 import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
@@ -51,11 +52,13 @@ public class EventEngineTaskDTOTest {
 
   @Test
   public void testFieldsCovered() throws Exception {
-    final GenericEventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class);
+    final GenericEventEngineTask task = (GenericEventEngineTask) podamFactory.manufacturePojo(GenericEventEngineTask.class)
+        .setMonitoringSystem(MonitoringSystem.SCOM.name());
 
     final EventEngineTaskDTO dto = new GenericEventEngineTaskDTO(task);
 
     assertThat(dto.getId(), notNullValue());
+    assertThat(dto.getMonitoringSystem(), notNullValue());
     assertThat(dto.getTenantId(), notNullValue());
     assertThat(dto.getName(), notNullValue());
     assertThat(dto.getMeasurement(), notNullValue());
@@ -64,6 +67,7 @@ public class EventEngineTaskDTOTest {
     assertThat(dto.getUpdatedTimestamp(), notNullValue());
 
     assertThat(dto.getId(), equalTo(task.getId()));
+    assertThat(dto.getMonitoringSystem(), equalTo(MonitoringSystem.valueOf(task.getMonitoringSystem())));
     assertThat(dto.getTenantId(), equalTo(task.getTenantId()));
     assertThat(dto.getName(), equalTo(task.getName()));
     assertThat(dto.getMeasurement(), equalTo(task.getMeasurement()));

--- a/src/test/resources/EventTaskApiClientTest/testPerformTestTask_req.json
+++ b/src/test/resources/EventTaskApiClientTest/testPerformTestTask_req.json
@@ -1,5 +1,6 @@
 {
   "task": {
+    "monitoringSystem": "uim",
     "measurement": "mem",
     "taskParameters": {
       "criticalStateDuration": 2,

--- a/src/test/resources/TasksControllerTest/get_task_response.json
+++ b/src/test/resources/TasksControllerTest/get_task_response.json
@@ -2,6 +2,7 @@
   "id": "00000000-0000-0000-0000-000000000000",
   "tenantId": "testSerialization",
   "name": "my-test-task",
+  "monitoringSystem": "UIM",
   "measurement": "disk",
   "taskParameters": {
     "criticalStateDuration": 5,


### PR DESCRIPTION
# Related PRs

https://github.com/racker/salus-event-engine-management/pull/73
https://github.com/racker/salus-telemetry-model/pull/162
https://github.com/racker/salus-telemetry-model/pull/163

# What

1. Allows for different types of tasks to be created for each monitor system
    * Uses changes from https://github.com/racker/salus-telemetry-model/pull/163
1. Had to also make DTOs and CU objects for each of those as well
   * We'll require different methods for handling all the different subtypes (currently only 2)
1. Made tests all use the generic type for now as it required the least change

# Note

* Uses `monitorScope` as the name for `ConfigSelectorScope`
    * This is also a proposal to change that in more places
    * It would make a little more sense to customers than `selectorScope`?
    * Anyone got a better name?

# Why

Each monitoring system may require different fields to be used for partitioning/filtering etc.

For salus the metrics will be partitioned by `tenantId:monitorType:monitorScope` and esper will also filter metrics using those fields.  That means those fields must be required in the task object.

However, maybe UIM doesn't have those fields and Tasks are configured differently.  For now it will fall under the `generic` subtype which can only use the `measurement` name.

This change allows us to add Salus specific changes that we know are needed without necessarily blocking us from handling other systems later on.

# TODO

Basic tests can probably be added for some of the new functionality.

I'm going to create a chain of additional PRs to this one to fully build out the new model while trying to keep each individual one easy(ish) to reivew