### PR TITLE
 Update to use new MonitoringSystem enum & Fix API (de)serialization

### DIFF
--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
@@ -18,7 +18,7 @@ package com.rackspace.salus.event.manage.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Create;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Test;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;

--- a/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
+++ b/src/main/java/com/rackspace/salus/event/manage/model/TaskCU.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.event.manage.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Create;
 import com.rackspace.salus.event.manage.model.ValidationGroups.Test;
@@ -29,8 +30,9 @@ import lombok.Data;
 
 
 @Data
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
-    property = "monitoringSystem", visible = true, defaultImpl = GenericTaskCU.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.EXISTING_PROPERTY,
+    property = "monitoringSystem", defaultImpl = GenericTaskCU.class,
+    visible = true)
 @JsonSubTypes({
     @JsonSubTypes.Type(name = "SALUS", value= SalusTaskCU.class)
 })

--- a/src/main/java/com/rackspace/salus/event/manage/services/TaskGenerator.java
+++ b/src/main/java/com/rackspace/salus/event/manage/services/TaskGenerator.java
@@ -63,7 +63,7 @@ public class TaskGenerator {
         .setMonitorScope(in.getMonitorScope())
         .setTenantId(tenantId)
         .setName(in.getName())
-        .setMonitoringSystem(in.getMonitoringSystem().name())
+        .setMonitoringSystem(in.getMonitoringSystem())
         .setTaskParameters(in.getTaskParameters());
   }
   private EventEngineTask createGenericTask(String tenantId, GenericTaskCU in) {
@@ -71,7 +71,7 @@ public class TaskGenerator {
         .setMeasurement(in.getMeasurement())
         .setTenantId(tenantId)
         .setName(in.getName())
-        .setMonitoringSystem(in.getMonitoringSystem().name())
+        .setMonitoringSystem(in.getMonitoringSystem())
         .setTaskParameters(in.getTaskParameters());
   }
 

--- a/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
+++ b/src/main/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTO.java
@@ -20,11 +20,10 @@ package com.rackspace.salus.event.manage.web.model;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
-import com.rackspace.monplat.protocol.UniversalMetricFrame;
-import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.entities.EventEngineTask;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import lombok.Data;
@@ -46,7 +45,7 @@ public abstract class EventEngineTaskDTO {
   EventEngineTaskParameters taskParameters;
   String createdTimestamp;
   String updatedTimestamp;
-  UniversalMetricFrame.MonitoringSystem monitoringSystem;
+  MonitoringSystem monitoringSystem;
 
   @JsonView(View.Admin.class)
   Integer partitionId;
@@ -54,7 +53,7 @@ public abstract class EventEngineTaskDTO {
 
   public EventEngineTaskDTO(EventEngineTask entity) {
     this.id = entity.getId();
-    this.monitoringSystem = MonitoringSystem.valueOf(entity.getMonitoringSystem());
+    this.monitoringSystem = entity.getMonitoringSystem();
     this.tenantId = entity.getTenantId();
     this.name = entity.getName();
     this.taskParameters = entity.getTaskParameters();

--- a/src/test/java/com/rackspace/salus/event/manage/services/TaskPartitionIdGeneratorTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TaskPartitionIdGeneratorTest.java
@@ -25,6 +25,7 @@ import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
 import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import java.time.Instant;
 import java.util.UUID;
 import org.apache.kafka.common.InvalidRecordException;
@@ -56,7 +57,7 @@ public class TaskPartitionIdGeneratorTest {
         .setName("myName")
         .setTenantId("t-2000")
         .setTaskParameters(null)
-        .setMonitoringSystem("UIM");
+        .setMonitoringSystem(MonitoringSystem.UIM);
 
     int id = taskPartitionIdGenerator.getPartitionForTask(eventEngineTask);
 
@@ -79,7 +80,7 @@ public class TaskPartitionIdGeneratorTest {
         .setName("myName")
         .setTenantId("t-3000")
         .setTaskParameters(null)
-        .setMonitoringSystem("UIM")
+        .setMonitoringSystem(MonitoringSystem.UIM)
         .setPartition(0);
 
     id = taskPartitionIdGenerator.getPartitionForTask(eventEngineTask2);
@@ -88,7 +89,7 @@ public class TaskPartitionIdGeneratorTest {
     // changing any other fields doesn't alter partition
     eventEngineTask2
         .setId(UUID.randomUUID())
-        .setMonitoringSystem("SCOM")
+        .setMonitoringSystem(MonitoringSystem.SCOM)
         .setTaskParameters(new EventEngineTaskParameters())
         .setCreatedTimestamp(Instant.now())
         .setUpdatedTimestamp(Instant.EPOCH)
@@ -107,7 +108,7 @@ public class TaskPartitionIdGeneratorTest {
         .setName("myName")
         .setTenantId("t-2000")
         .setTaskParameters(null)
-        .setMonitoringSystem("UIM");
+        .setMonitoringSystem(MonitoringSystem.UIM);
 
     int id = taskPartitionIdGenerator.getPartitionForTask(eventEngineTask);
 
@@ -131,7 +132,7 @@ public class TaskPartitionIdGeneratorTest {
         .setName("myName")
         .setTenantId("t-3000")
         .setTaskParameters(null)
-        .setMonitoringSystem("UIM");
+        .setMonitoringSystem(MonitoringSystem.UIM);
 
     id = taskPartitionIdGenerator.getPartitionForTask(eventEngineTask2);
     assertThat(id).isEqualTo(25);
@@ -139,7 +140,7 @@ public class TaskPartitionIdGeneratorTest {
     // changing any other fields doesn't alter partition
     eventEngineTask2
         .setId(UUID.randomUUID())
-        .setMonitoringSystem("SALUS")
+        .setMonitoringSystem(MonitoringSystem.SALUS)
         .setTaskParameters(new EventEngineTaskParameters())
         .setCreatedTimestamp(Instant.now())
         .setUpdatedTimestamp(Instant.EPOCH)

--- a/src/test/java/com/rackspace/salus/event/manage/services/TasksServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TasksServiceTest.java
@@ -110,7 +110,7 @@ public class TasksServiceTest {
     GenericEventEngineTask task = (GenericEventEngineTask) retrieved.get();
     // timestamps are returned with slightly less precision on the retrieval
     assertThat(task).isEqualToIgnoringGivenFields(created, "createdTimestamp", "updatedTimestamp");
-    assertThat(task.getMonitoringSystem()).isEqualTo("UIM");
+    assertThat(task.getMonitoringSystem()).isEqualTo(MonitoringSystem.UIM);
     assertThat(task.getMeasurement()).isEqualTo(taskIn.getMeasurement());
     assertThat(task.getPartition()).isEqualTo(6);
 
@@ -132,7 +132,7 @@ public class TasksServiceTest {
     SalusEventEngineTask task = (SalusEventEngineTask) retrieved.get();
     // timestamps are returned with slightly less precision on the retrieval
     assertThat(task).isEqualToIgnoringGivenFields(created, "createdTimestamp", "updatedTimestamp");
-    assertThat(task.getMonitoringSystem()).isEqualTo("SALUS");
+    assertThat(task.getMonitoringSystem()).isEqualTo(MonitoringSystem.SALUS);
     assertThat(task.getMonitorType()).isEqualTo(taskIn.getMonitorType());
     assertThat(task.getMonitorScope()).isEqualTo(taskIn.getMonitorScope());
     assertThat(task.getPartition()).isEqualTo(6);

--- a/src/test/java/com/rackspace/salus/event/manage/services/TasksServiceTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/services/TasksServiceTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.event.manage.config.DatabaseConfig;
 import com.rackspace.salus.event.manage.model.GenericTaskCU;
 import com.rackspace.salus.event.manage.model.SalusTaskCU;
@@ -39,6 +38,7 @@ import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
 import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.repositories.EventEngineTaskRepository;
 import com.rackspace.salus.test.EnableTestContainersDatabase;
@@ -309,7 +309,7 @@ public class TasksServiceTest {
         .setName(taskIn.getName())
         .setTenantId("t-1")
         .setTaskParameters(taskIn.getTaskParameters())
-        .setMonitoringSystem(taskIn.getMonitoringSystem().name())
+        .setMonitoringSystem(taskIn.getMonitoringSystem())
         .setPartition(0);
     return eventEngineTaskRepository.save(eventEngineTask);
   }
@@ -329,7 +329,7 @@ public class TasksServiceTest {
         .setName(taskIn.getName())
         .setTenantId("t-1")
         .setTaskParameters(taskIn.getTaskParameters())
-        .setMonitoringSystem(taskIn.getMonitoringSystem().name())
+        .setMonitoringSystem(taskIn.getMonitoringSystem())
         .setPartition(0);
     return eventEngineTaskRepository.save(eventEngineTask);
   }

--- a/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
@@ -40,7 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.event.discovery.EventEnginePicker;
 import com.rackspace.salus.event.manage.errors.TestTimedOutException;
 import com.rackspace.salus.event.manage.model.GenericTaskCU;
@@ -67,6 +66,7 @@ import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
 import com.rackspace.salus.telemetry.model.CustomEvalNode;
 import com.rackspace.salus.telemetry.model.DerivativeNode;
 import com.rackspace.salus.telemetry.model.MetricExpressionBase;
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import com.rackspace.salus.telemetry.model.PercentageEvalNode;
 import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
@@ -180,7 +180,7 @@ public class TasksApiControllerTest {
     List<EventEngineTask> tasks = new ArrayList<>();
     for (int i = 0; i < numberOfTasks; i++) {
       tasks.add(podamFactory.manufacturePojo(SalusEventEngineTask.class)
-          .setMonitoringSystem(MonitoringSystem.SALUS.name()));
+          .setMonitoringSystem(MonitoringSystem.SALUS));
     }
 
     int start = page * pageSize;
@@ -246,7 +246,7 @@ public class TasksApiControllerTest {
   @Test
   public void testCreateTask() throws Exception {
     EventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class)
-        .setMonitoringSystem(MonitoringSystem.UIM.name());
+        .setMonitoringSystem(MonitoringSystem.UIM);
     when(tasksService.createTask(anyString(), any()))
         .thenReturn(task);
 
@@ -270,7 +270,7 @@ public class TasksApiControllerTest {
   @Test
   public void testUpdateTask() throws Exception {
     EventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class)
-        .setMonitoringSystem(MonitoringSystem.MAAS.name());
+        .setMonitoringSystem(MonitoringSystem.MAAS);
     when(tasksService.updateTask(anyString(), any(), any()))
         .thenReturn(task);
 
@@ -572,7 +572,7 @@ public class TasksApiControllerTest {
     return new GenericEventEngineTask()
         .setMeasurement("disk")
         .setPartition(8)
-        .setMonitoringSystem(MonitoringSystem.UIM.name())
+        .setMonitoringSystem(MonitoringSystem.UIM)
         .setId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH)

--- a/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/controller/TasksApiControllerTest.java
@@ -338,7 +338,8 @@ public class TasksApiControllerTest {
 
   @Test
   public void testCreateTask_MissingName() throws Exception {
-    EventEngineTask task = podamFactory.manufacturePojo(EventEngineTask.class);
+    EventEngineTask task = podamFactory.manufacturePojo(GenericEventEngineTask.class)
+        .setMonitoringSystem(MonitoringSystem.UIM);
     when(tasksService.createTask(anyString(), any()))
         .thenReturn(task);
 

--- a/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
+++ b/src/test/java/com/rackspace/salus/event/manage/web/model/EventEngineTaskDTOTest.java
@@ -22,10 +22,10 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.ComparisonExpression;
 import com.rackspace.salus.telemetry.entities.subtype.GenericEventEngineTask;
+import com.rackspace.salus.telemetry.model.MonitoringSystem;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import uk.co.jemos.podam.api.DefaultClassInfoStrategy;
@@ -53,7 +53,7 @@ public class EventEngineTaskDTOTest {
   @Test
   public void testFieldsCovered() throws Exception {
     final GenericEventEngineTask task = (GenericEventEngineTask) podamFactory.manufacturePojo(GenericEventEngineTask.class)
-        .setMonitoringSystem(MonitoringSystem.SCOM.name());
+        .setMonitoringSystem(MonitoringSystem.SCOM);
 
     final EventEngineTaskDTO dto = new GenericEventEngineTaskDTO(task);
 
@@ -68,7 +68,7 @@ public class EventEngineTaskDTOTest {
     assertThat(dto.getUpdatedTimestamp(), notNullValue());
 
     assertThat(dto.getId(), equalTo(task.getId()));
-    assertThat(dto.getMonitoringSystem(), equalTo(MonitoringSystem.valueOf(task.getMonitoringSystem())));
+    assertThat(dto.getMonitoringSystem(), equalTo(task.getMonitoringSystem()));
     assertThat(dto.getTenantId(), equalTo(task.getTenantId()));
     assertThat(dto.getName(), equalTo(task.getName()));
     assertThat(dto.getMeasurement(), equalTo(task.getMeasurement()));

--- a/src/test/resources/EventTaskApiClientTest/testPerformTestTask_req.json
+++ b/src/test/resources/EventTaskApiClientTest/testPerformTestTask_req.json
@@ -1,6 +1,6 @@
 {
   "task": {
-    "monitoringSystem": "uim",
+    "monitoringSystem": "UIM",
     "measurement": "mem",
     "taskParameters": {
       "criticalStateDuration": 2,


### PR DESCRIPTION
Updating services to use the new `MonitoringSystem` enum in salus-models instead of the one in umb-protocol.

See https://github.com/racker/salus-telemetry-model/pull/165 for more info

---

This also fixes up the API usage problem that was leftover from the recently merged PRs,

